### PR TITLE
Updates repl-port file location

### DIFF
--- a/lib/session.coffee
+++ b/lib/session.coffee
@@ -25,7 +25,7 @@ class Session
           fn(error)
 
 getPort = (self, fn) ->
-  portFilePath = path.join(self.directory.path, "target", "repl-port")
+  portFilePath = path.join(self.directory.path, "target", "repl", "repl-port")
 
   fs.exists portFilePath, (result) ->
     if result


### PR DESCRIPTION
Hey-- full disclosure, I'm new to clojure and may have overlooked something obvious.

That said, nrepl appears to store the port in ./target/repl/nrepl-port when I use the specified version. After making this change, the package works as documented.
