### PR TITLE
Fix deprecated selector

### DIFF
--- a/keymaps/nrepl.cson
+++ b/keymaps/nrepl.cson
@@ -1,2 +1,2 @@
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-e': 'nrepl:eval'


### PR DESCRIPTION
Atom has a built-in "Deprecation cop" which hints about a new selector to use instead of this deprecated one.

Would need a new release though.