### PR TITLE
Update nrepl.cson

### DIFF
--- a/keymaps/nrepl.cson
+++ b/keymaps/nrepl.cson
@@ -1,2 +1,2 @@
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-e': 'nrepl:eval'


### PR DESCRIPTION
Update the nrepl.cson to match the corrected atom behavior. It currently shows in the deprecation cop section of atom. I ran it locally and it seemed to work fine.